### PR TITLE
Search inventory by pressing enter

### DIFF
--- a/mods/player_style/inv.lua
+++ b/mods/player_style/inv.lua
@@ -400,6 +400,7 @@ player_style.inventory=function(player)
 			.."label[13.6,7.9;"..page.."/"..pages.."]"
 
 			.."field[12.3,6.5;3,1;searchbox;;"..(invp.search and invp.search.text or "").."]"
+			.. "field_close_on_enter[searchbox;false]"
 			.."image_button[15,6.3;1,0.8;player_style_search.png;search;]"
 			..model
 			..backpack


### PR DESCRIPTION
Fixes searching the inventory by pressing enter. 
Adds a field_close_on_enter element that does the job.

It took me a while to find out that the inventory mod is named player_style.
I highly recommend renaming the inventory mod.